### PR TITLE
Possible fix for storing filenames

### DIFF
--- a/a/incz/kzoemiaa.h
+++ b/a/incz/kzoemiaa.h
@@ -256,8 +256,8 @@ struct FileHeaderStruct
 {
    zCHAR                chTypeIndicator[ 6 ];
    zCHAR                szZeidon[ 10 ];
-   zCHAR                szFileName[ 32 ];
-   zCHAR                szObjectType[ 9 ];
+   zCHAR                szFileName[ zZEIDON_NAME_LTH + 1 ];
+   zCHAR                szObjectType[ zZEIDON_NAME_LTH + 1 ];
    zCHAR                szDate[ 11 ];
    zCHAR                szTime[ 9 ];
    zCHAR                szRelease[ 9 ];


### PR DESCRIPTION
I'm not sure where this structure is used but it looks like szObjectType is supposed to store the name of the LOD.  LOD names used to be restricted to 8 chars but now it can be 32 so I've updated the buffer size.

I'm not sure about szFileName.  If it stores the entire path name then it's gonna be a problem as well and needs to be made bigger.
